### PR TITLE
Add Service Provider configuration file

### DIFF
--- a/src/main/resources/META-INF/services/org.apache.kafka.common.config.provider.ConfigProvider
+++ b/src/main/resources/META-INF/services/org.apache.kafka.common.config.provider.ConfigProvider
@@ -1,0 +1,5 @@
+# Copyright Strimzi authors.
+# License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+
+io.strimzi.kafka.KubernetesConfigMapConfigProvider
+io.strimzi.kafka.KubernetesSecretConfigProvider

--- a/src/test/java/io/strimzi/kafka/KubernetesResourceIdentifierTest.java
+++ b/src/test/java/io/strimzi/kafka/KubernetesResourceIdentifierTest.java
@@ -34,5 +34,4 @@ public class KubernetesResourceIdentifierTest {
         e = assertThrows(ConfigException.class, () -> KubernetesResourceIdentifier.fromConfigString("my-namespace/my-resource/my-field"));
         assertThat(e.getMessage(), is("Invalid path my-namespace/my-resource/my-field. It has to be in format <namespace>/<secret>."));
     }
-
 }

--- a/src/test/java/io/strimzi/kafka/ServiceLoaderTest.java
+++ b/src/test/java/io/strimzi/kafka/ServiceLoaderTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka;
+
+import org.apache.kafka.common.config.provider.ConfigProvider;
+import org.junit.jupiter.api.Test;
+
+import java.util.ServiceLoader;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ServiceLoaderTest {
+    @Test
+    public void testServiceLoaderDiscovery() {
+        ServiceLoader<ConfigProvider> serviceLoader = ServiceLoader.load(ConfigProvider.class);
+
+        boolean configMapProviderDiscovered = false;
+        boolean secretProviderDiscovered = false;
+
+        for (ConfigProvider service : serviceLoader)    {
+            System.out.println(service.getClass());
+            if (service instanceof KubernetesSecretConfigProvider) {
+                secretProviderDiscovered = true;
+            } else if (service instanceof KubernetesConfigMapConfigProvider) {
+                configMapProviderDiscovered = true;
+            }
+        }
+
+        assertTrue(secretProviderDiscovered);
+        assertTrue(configMapProviderDiscovered);
+    }
+}


### PR DESCRIPTION
When the configuration provider is loaded as a plugin in Kafka Connect, it is loaded as a [Service Provider](https://docs.oracle.com/javase/8/docs/technotes/guides/jar/jar.html#Service_Provider). To be able to do this, we need to add the configuration file which lists the service implementations.