### PR TITLE
Make namespace optional and update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,13 @@ For example:
 option=${secrets:my-namespace/my-secret:my-key}
 ```
 
+Alternatively, you can also use the form `<RESOURCE-NAME>:<KEY>`.
+Where:
+* The `<RESOURCE-NAME>` is the name of the Secret or Config Map
+* The `<KEY>` is the key under which the configuration value is stored in the Secret or Config Map
+
+In this case, the current namespace of the Kubernetes client will be used.
+
 The following example shows how to use it in a Kafka Consumer consuming from Apache Kafka cluster on Kubernetes using Strimzi:
 
 1) Deploy your Kafka cluster with TLS authentication enabled

--- a/pom.xml
+++ b/pom.xml
@@ -83,11 +83,12 @@
         <maven.gpg.version>1.6</maven.gpg.version>
         <sonatype.nexus.staging>1.6.3</sonatype.nexus.staging>
 
-        <kafka.version>3.0.0</kafka.version>
-        <fabric8-kubernetes-client.version>5.8.0</fabric8-kubernetes-client.version>
+        <kafka.version>3.1.0</kafka.version>
+        <fabric8-kubernetes-client.version>5.12.0</fabric8-kubernetes-client.version>
 
         <junit5.version>5.7.2</junit5.version>
         <hamcrest.version>2.2</hamcrest.version>
+        <mockito.version>2.28.2</mockito.version>
 	</properties>
 
     <distributionManagement>
@@ -130,10 +131,6 @@
                 <exclusion>
                     <groupId>io.fabric8</groupId>
                     <artifactId>kubernetes-model-autoscaling</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.fabric8</groupId>
-                    <artifactId>kubernetes-model-certificates</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>io.fabric8</groupId>
@@ -197,6 +194,12 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
             <version>${hamcrest.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/io/strimzi/kafka/AbstractKubernetesConfigProvider.java
+++ b/src/main/java/io/strimzi/kafka/AbstractKubernetesConfigProvider.java
@@ -108,7 +108,7 @@ abstract class AbstractKubernetesConfigProvider<T extends HasMetadata, L extends
      * @return      Resource retrieved from the Kubernetes cluster
      */
     protected T getResource(String path)   {
-        final KubernetesResourceIdentifier resourceIdentifier = KubernetesResourceIdentifier.fromConfigString(path);
+        final KubernetesResourceIdentifier resourceIdentifier = KubernetesResourceIdentifier.fromConfigString(client, path);
 
         LOG.info("Retrieving configuration from {} {} in namespace {}", kind, resourceIdentifier.getName(), resourceIdentifier.getNamespace());
 

--- a/src/test/java/io/strimzi/kafka/KubernetesConfigMapProviderIT.java
+++ b/src/test/java/io/strimzi/kafka/KubernetesConfigMapProviderIT.java
@@ -90,6 +90,17 @@ public class KubernetesConfigMapProviderIT {
     }
 
     @Test
+    public void testDefaultNamespace() {
+        ConfigData config = provider.get(RESOURCE_NAME);
+        Map<String, String> data = config.data();
+
+        assertThat(data.size(), is(3));
+        assertThat(data.get("test-key-1"), is("test-value-1"));
+        assertThat(data.get("test-key-2"), is("test-value-2"));
+        assertThat(data.get("test-key-3"), is("test-value-3"));
+    }
+
+    @Test
     public void testNonExistentConfigMap() {
         assertThrows(ConfigException.class, () -> provider.get(namespace + "/i-do-not-exist"));
         assertThrows(ConfigException.class, () -> provider.get("i-do-not-exist/i-do-not-exist-either"));

--- a/src/test/java/io/strimzi/kafka/KubernetesResourceIdentifierTest.java
+++ b/src/test/java/io/strimzi/kafka/KubernetesResourceIdentifierTest.java
@@ -4,34 +4,60 @@
  */
 package io.strimzi.kafka;
 
+import io.fabric8.kubernetes.client.Client;
 import org.apache.kafka.common.config.ConfigException;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class KubernetesResourceIdentifierTest {
+    private static Client client;
+
+    @BeforeAll
+    static void setUp()   {
+        client = mock(Client.class);
+        when(client.getNamespace()).thenReturn("default-namespace");
+    }
+
     @Test
     public void testValidResourceIdentifierParsing()    {
-        KubernetesResourceIdentifier id = KubernetesResourceIdentifier.fromConfigString("my-namespace/my-resource");
+        KubernetesResourceIdentifier id = KubernetesResourceIdentifier.fromConfigString(client, "my-namespace/my-resource");
 
         assertThat(id.getNamespace(), is("my-namespace"));
         assertThat(id.getName(), is("my-resource"));
     }
 
     @Test
+    public void testValidResourceIdentifierParsingWithoutNamespace()    {
+        KubernetesResourceIdentifier id = KubernetesResourceIdentifier.fromConfigString(client, "my-resource");
+
+        assertThat(id.getNamespace(), is("default-namespace"));
+        assertThat(id.getName(), is("my-resource"));
+    }
+
+    @Test
     public void testInvalidResourceIdentifierParsing()    {
-        ConfigException e = assertThrows(ConfigException.class, () -> KubernetesResourceIdentifier.fromConfigString("my-namespace"));
-        assertThat(e.getMessage(), is("Invalid path my-namespace. It has to be in format <namespace>/<secret>."));
+        Exception e = assertThrows(ConfigException.class, () -> KubernetesResourceIdentifier.fromConfigString(client, "my-namespace//my-resource"));
+        assertThat(e.getMessage(), is("Invalid path my-namespace//my-resource. It has to be in format <namespace>/<secret> (or <secret> for default namespace)."));
 
-        e = assertThrows(ConfigException.class, () -> KubernetesResourceIdentifier.fromConfigString("my-namespace//my-resource"));
-        assertThat(e.getMessage(), is("Invalid path my-namespace//my-resource. It has to be in format <namespace>/<secret>."));
+        e = assertThrows(ConfigException.class, () -> KubernetesResourceIdentifier.fromConfigString(client, "my-namespace/"));
+        assertThat(e.getMessage(), is("Invalid path my-namespace/. It has to be in format <namespace>/<secret> (or <secret> for default namespace)."));
 
-        e = assertThrows(ConfigException.class, () -> KubernetesResourceIdentifier.fromConfigString("my-namespace/"));
-        assertThat(e.getMessage(), is("Invalid path my-namespace/. It has to be in format <namespace>/<secret>."));
+        e = assertThrows(ConfigException.class, () -> KubernetesResourceIdentifier.fromConfigString(client, "/my-namespace"));
+        assertThat(e.getMessage(), is("Invalid path /my-namespace. It has to be in format <namespace>/<secret> (or <secret> for default namespace)."));
 
-        e = assertThrows(ConfigException.class, () -> KubernetesResourceIdentifier.fromConfigString("my-namespace/my-resource/my-field"));
-        assertThat(e.getMessage(), is("Invalid path my-namespace/my-resource/my-field. It has to be in format <namespace>/<secret>."));
+        e = assertThrows(ConfigException.class, () -> KubernetesResourceIdentifier.fromConfigString(client, "my-namespace/my-resource/my-field"));
+        assertThat(e.getMessage(), is("Invalid path my-namespace/my-resource/my-field. It has to be in format <namespace>/<secret> (or <secret> for default namespace)."));
+
+        e = assertThrows(ConfigException.class, () -> KubernetesResourceIdentifier.fromConfigString(client, "my-namespace/my-resource/"));
+        assertThat(e.getMessage(), is("Invalid path my-namespace/my-resource/. It has to be in format <namespace>/<secret> (or <secret> for default namespace)."));
+
+        e = assertThrows(ConfigException.class, () -> KubernetesResourceIdentifier.fromConfigString(client, "/my-namespace/my-resource"));
+        assertThat(e.getMessage(), is("Invalid path /my-namespace/my-resource. It has to be in format <namespace>/<secret> (or <secret> for default namespace)."));
     }
 }

--- a/src/test/java/io/strimzi/kafka/KubernetesSecretProviderIT.java
+++ b/src/test/java/io/strimzi/kafka/KubernetesSecretProviderIT.java
@@ -94,6 +94,18 @@ public class KubernetesSecretProviderIT {
     }
 
     @Test
+    public void testDefaultNamespace() {
+        ConfigData config = provider.get(RESOURCE_NAME);
+        Map<String, String> data = config.data();
+
+        assertThat(data.size(), is(4));
+        assertThat(data.get("test-key-1"), is("test-value-1"));
+        assertThat(data.get("test-key-2"), is("test-value-2"));
+        assertThat(data.get("test-key-3"), is("test-value-3"));
+        assertThat(data.get("test-key-4"), is("test-value-4"));
+    }
+
+    @Test
     public void testNonExistentSecret() {
         assertThrows(ConfigException.class, () -> provider.get(namespace + "/i-do-not-exist"));
         assertThrows(ConfigException.class, () -> provider.get("i-do-not-exist/i-do-not-exist-either"));


### PR DESCRIPTION
This PR makes the namespace optional. When the namespace is not specified, the default namespace will be automatically used. This makes is easier in some cases to have a more portable configuration. For example, when the application is deployed into different namespaces in different environments, but always reads a secret or config map from its own namespace, it does not need to specify the namespace now and will always wotk fine. This should close #6.

It also updates the dependencies - Kafka version and the Fabric8 Kubernetes Client version. The dependency changes are limited only to the `pom.xml` file. 

_(Sorry for doing two things in one PR. It made it much easier to manually test it both together in one change.)_