### PR TITLE
Update Fabric8 to 6.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,8 +83,8 @@
         <maven.gpg.version>1.6</maven.gpg.version>
         <sonatype.nexus.staging>1.6.3</sonatype.nexus.staging>
 
-        <kafka.version>3.1.0</kafka.version>
-        <fabric8-kubernetes-client.version>5.12.0</fabric8-kubernetes-client.version>
+        <kafka.version>3.2.1</kafka.version>
+        <fabric8-kubernetes-client.version>6.0.0</fabric8-kubernetes-client.version>
 
         <junit5.version>5.7.2</junit5.version>
         <hamcrest.version>2.2</hamcrest.version>


### PR DESCRIPTION
This PR updates the Fabric8 dependency to 6.0.0. It does not require any changes in the code or tests. But apart from staying up-to-date with the Fabric8 library, it removes some dependencies such as `com.github.mifmif:generex` and `dk.brics.automaton:automaton`.

It also bumps the Kafka depndency to Kafka 3.2.1. This does not impact any code either. Kafka is provided dependency, so this update is more formal rather than meaning anything. But might help for example with security scanners which might not completely understand how Kafka is used here.