### PR TITLE
Add direct OkHttpClientFactory usage (#12)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-httpclient-okhttp</artifactId>
+            <version>${fabric8-kubernetes-client.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>${junit5.version}</version>

--- a/src/main/java/io/strimzi/kafka/AbstractKubernetesConfigProvider.java
+++ b/src/main/java/io/strimzi/kafka/AbstractKubernetesConfigProvider.java
@@ -6,11 +6,12 @@ package io.strimzi.kafka;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
-import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.okhttp.OkHttpClientFactory;
 import org.apache.kafka.common.config.ConfigData;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.provider.ConfigProvider;
@@ -60,7 +61,9 @@ abstract class AbstractKubernetesConfigProvider<T extends HasMetadata, L extends
     @Override
     public void configure(Map<String, ?> map) {
         LOG.info("Configuring Kubernetes {} config provider", kind);
-        client = new DefaultKubernetesClient();
+        client = new KubernetesClientBuilder()
+            .withHttpClientFactory(new OkHttpClientFactory())
+            .build();
     }
 
     @Override

--- a/src/test/java/io/strimzi/kafka/KubernetesConfigMapProviderIT.java
+++ b/src/test/java/io/strimzi/kafka/KubernetesConfigMapProviderIT.java
@@ -6,8 +6,9 @@ package io.strimzi.kafka;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
-import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.kubernetes.client.okhttp.OkHttpClientFactory;
 import org.apache.kafka.common.config.ConfigData;
 import org.apache.kafka.common.config.ConfigException;
 import org.junit.jupiter.api.AfterAll;
@@ -37,7 +38,9 @@ public class KubernetesConfigMapProviderIT {
         provider = new KubernetesConfigMapConfigProvider();
         provider.configure(emptyMap());
 
-        client = new DefaultKubernetesClient();
+        client = new KubernetesClientBuilder()
+            .withHttpClientFactory(new OkHttpClientFactory())
+            .build();
         namespace = client.getNamespace();
 
         ConfigMap cm = new ConfigMapBuilder()

--- a/src/test/java/io/strimzi/kafka/KubernetesSecretProviderIT.java
+++ b/src/test/java/io/strimzi/kafka/KubernetesSecretProviderIT.java
@@ -6,8 +6,9 @@ package io.strimzi.kafka;
 
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
-import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.kubernetes.client.okhttp.OkHttpClientFactory;
 import org.apache.kafka.common.config.ConfigData;
 import org.apache.kafka.common.config.ConfigException;
 import org.junit.jupiter.api.AfterAll;
@@ -38,7 +39,9 @@ public class KubernetesSecretProviderIT {
         provider = new KubernetesSecretConfigProvider();
         provider.configure(emptyMap());
 
-        client = new DefaultKubernetesClient();
+        client = new KubernetesClientBuilder()
+            .withHttpClientFactory(new OkHttpClientFactory())
+            .build();
         namespace = client.getNamespace();
 
         Secret secret = new SecretBuilder()


### PR DESCRIPTION
This PR adds direct `OkHttpClientFactory` usage. This solves the issue #12 with loading the `HttpClient` implementation when kafka-kubernetes-config-provider is deployed in the directory specified in the `plugin.path` property.

Signed-off-by: jchipmunk <andrey.pustovetov@gmail.com>