### PR TITLE
Override okhttp 3.x pulled in by Fabric8 Kubernetes Client with okhttp 4.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,7 @@
         <kafka.version>3.3.1</kafka.version>
         <slf4j.version>1.7.36</slf4j.version>
         <fabric8-kubernetes-client.version>6.2.0</fabric8-kubernetes-client.version>
+        <okhttp.version>4.9.3</okhttp.version>
 
         <junit5.version>5.7.2</junit5.version>
         <hamcrest.version>2.2</hamcrest.version>
@@ -178,6 +179,16 @@
                     <groupId>io.fabric8</groupId>
                     <artifactId>kubernetes-model-storageclass</artifactId>
                 </exclusion>
+
+                <!-- Remove transitive dependencies brought in for okhttp 3.x -->
+                <exclusion>
+                    <groupId>com.squareup.okhttp3</groupId>
+                    <artifactId>okhttp</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.squareup.okhttp3</groupId>
+                    <artifactId>logging-interceptor</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -191,6 +202,21 @@
             <artifactId>kubernetes-httpclient-okhttp</artifactId>
             <version>${fabric8-kubernetes-client.version}</version>
         </dependency>
+
+        <!-- Override okhttp version used by fabric8 kubernetes-client -->
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>${okhttp.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>logging-interceptor</artifactId>
+            <version>${okhttp.version}</version>
+        </dependency>
+
+        <!-- Tests dependencies -->
+
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>


### PR DESCRIPTION
Fabric8 Kubernetes Client 6.2.0 pulls in a dependency on `okhttp-3.x` which during bundling into `kafka/libs` folder conflicts with `okhttp-4.x` brought in by `opentelemetry`.

Only one can be present in `kafka/libs`.

OkHttp 4.x is a drop-in replacement for 3.x so we can replace it in this project to catch any potential issues (none expected) as soon as possible.

Instructions are available at:
https://github.com/fabric8io/kubernetes-client/blob/v6.2.0/doc/KubernetesClientWithIPv6Clusters.md

Signed-off-by: Marko Strukelj <marko.strukelj@gmail.com>