### PR TITLE
Bump main branch version to 1.2.0-SNAPSHOT and update Java setup in CodeQL to avoid deprecated step

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,10 +38,11 @@ jobs:
       uses: actions/checkout@v2
     
     # Setup OpenJDK 11
-    - name: Setup java
-      uses: joschi/setup-jdk@v2
+    - uses: actions/setup-java@v2
       with:
-        java-version: 11
+        distribution: 'temurin'
+        java-version: '11'
+        cache: 'maven'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.strimzi</groupId>
     <artifactId>kafka-kubernetes-config-provider</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
 
     <licenses>
 		<license>


### PR DESCRIPTION
As we are preparing 1.1.0 release, we should bump the version in main branch to 1.2.0-SNAPSHOT. This is done in this PR. It also updated the GItHub CodeQL action to avoid use of deprecated Java setup step and use the official one.