### PR TITLE
Move from OkHttp to JDK HTTP client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,10 @@
             <exclusions>
                 <exclusion>
                     <groupId>io.fabric8</groupId>
+                    <artifactId>kubernetes-httpclient-okhttp</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.fabric8</groupId>
                     <artifactId>kubernetes-model-admissionregistration</artifactId>
                 </exclusion>
                 <exclusion>
@@ -177,15 +181,15 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-httpclient-jdk</artifactId>
+            <version>${fabric8-kubernetes-client.version}</version>
+        </dependency>
+        <dependency>
             <!-- Override for SnakeYAML 1.33 pulled by Jackson 1.14.2 -->
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
             <version>2.0</version>
-        </dependency>
-        <dependency>
-            <groupId>io.fabric8</groupId>
-            <artifactId>kubernetes-httpclient-okhttp</artifactId>
-            <version>${fabric8-kubernetes-client.version}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/io/strimzi/kafka/AbstractKubernetesConfigProvider.java
+++ b/src/main/java/io/strimzi/kafka/AbstractKubernetesConfigProvider.java
@@ -11,7 +11,6 @@ import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.kubernetes.client.okhttp.OkHttpClientFactory;
 import org.apache.kafka.common.config.ConfigData;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.provider.ConfigProvider;
@@ -61,9 +60,7 @@ abstract class AbstractKubernetesConfigProvider<T extends HasMetadata, L extends
     @Override
     public void configure(Map<String, ?> map) {
         LOG.info("Configuring Kubernetes {} config provider", kind);
-        client = new KubernetesClientBuilder()
-            .withHttpClientFactory(new OkHttpClientFactory())
-            .build();
+        client = new KubernetesClientBuilder().build();
     }
 
     @Override

--- a/src/test/java/io/strimzi/kafka/KubernetesConfigMapProviderIT.java
+++ b/src/test/java/io/strimzi/kafka/KubernetesConfigMapProviderIT.java
@@ -8,7 +8,6 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
-import io.fabric8.kubernetes.client.okhttp.OkHttpClientFactory;
 import org.apache.kafka.common.config.ConfigData;
 import org.apache.kafka.common.config.ConfigException;
 import org.junit.jupiter.api.AfterAll;
@@ -38,9 +37,7 @@ public class KubernetesConfigMapProviderIT {
         provider = new KubernetesConfigMapConfigProvider();
         provider.configure(emptyMap());
 
-        client = new KubernetesClientBuilder()
-            .withHttpClientFactory(new OkHttpClientFactory())
-            .build();
+        client = new KubernetesClientBuilder().build();
         namespace = client.getNamespace();
 
         ConfigMap cm = new ConfigMapBuilder()

--- a/src/test/java/io/strimzi/kafka/KubernetesSecretProviderIT.java
+++ b/src/test/java/io/strimzi/kafka/KubernetesSecretProviderIT.java
@@ -8,7 +8,6 @@ import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
-import io.fabric8.kubernetes.client.okhttp.OkHttpClientFactory;
 import org.apache.kafka.common.config.ConfigData;
 import org.apache.kafka.common.config.ConfigException;
 import org.junit.jupiter.api.AfterAll;
@@ -39,9 +38,7 @@ public class KubernetesSecretProviderIT {
         provider = new KubernetesSecretConfigProvider();
         provider.configure(emptyMap());
 
-        client = new KubernetesClientBuilder()
-            .withHttpClientFactory(new OkHttpClientFactory())
-            .build();
+        client = new KubernetesClientBuilder().build();
         namespace = client.getNamespace();
 
         Secret secret = new SecretBuilder()


### PR DESCRIPTION
The Kubernetes Config Provider currently still uses the OkHttp 3 as the HTTP client which has CVEs. This PR changes it to use the JDK HTTP client to remove the OkHttp dependency.