### PR TITLE
Update dependencies (Fabric8 6.8.0 and Kafka 3.5.1)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,9 +84,9 @@
         <maven.gpg.version>3.0.1</maven.gpg.version>
         <sonatype.nexus.staging>1.6.7</sonatype.nexus.staging>
 
-        <kafka.version>3.4.0</kafka.version>
+        <kafka.version>3.5.1</kafka.version>
         <slf4j.version>1.7.36</slf4j.version>
-        <fabric8-kubernetes-client.version>6.5.0</fabric8-kubernetes-client.version>
+        <fabric8-kubernetes-client.version>6.8.0</fabric8-kubernetes-client.version>
 
         <junit5.version>5.7.2</junit5.version>
         <hamcrest.version>2.2</hamcrest.version>


### PR DESCRIPTION
This PR updates some dependencies of the config provider:
* Fabric8 Kubernetes client is updated to 6.8.0
* Kafka is updated to 3.5.1