### PR TITLE
Provide better logging for Kubernetes client issues

### DIFF
--- a/src/main/java/io/strimzi/kafka/AbstractKubernetesConfigProvider.java
+++ b/src/main/java/io/strimzi/kafka/AbstractKubernetesConfigProvider.java
@@ -121,7 +121,8 @@ abstract class AbstractKubernetesConfigProvider<T extends HasMetadata, L extends
 
             return resource;
         } catch (KubernetesClientException e)   {
-            throw new ConfigException("Failed to retrieve " + kind +  " " + resourceIdentifier.getName() + " from Kubernetes namespace " + resourceIdentifier.getNamespace(), e);
+            LOG.error("Failed to retrieve " + kind +  " " + resourceIdentifier.getName() + " from Kubernetes namespace " + resourceIdentifier.getNamespace(), e);
+            throw new ConfigException("Failed to retrieve " + kind +  " " + resourceIdentifier.getName() + " from Kubernetes namespace " + resourceIdentifier.getNamespace());
         }
     }
 }


### PR DESCRIPTION
When the Kubernetes client throws an exception, we currently try to convert it to Kafka `ConfigException`. That is wrong because `ConfigException` does not keep the original exception and it takes the exception as the expected value instead. This PR fixes the error handling:
* It loges the KubernetesClientException in our code
* Passes `ConfigException` to Kafka with a proper message