### PR TITLE
Allow using patterns to match multiple Secret or ConfigMap fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,17 +23,17 @@ The following example shows how to use it with Kafka Connect and Connectors:
     apiVersion: kafka.strimzi.io/v1beta2
     kind: KafkaConnect
     metadata:
-      name: my-connect
-      annotations:
-        strimzi.io/use-connector-resources: "true"
+      name: my-connect
+      annotations:
+        strimzi.io/use-connector-resources: "true"
     spec:
-      # ...
-      config:
-        # ...
-        config.providers: secrets,configmaps
-        config.providers.secrets.class: io.strimzi.kafka.KubernetesSecretConfigProvider
-        config.providers.configmaps.class: io.strimzi.kafka.KubernetesConfigMapConfigProvider
-      # ...
+      # ...
+      config:
+        # ...
+        config.providers: secrets,configmaps
+        config.providers.secrets.class: io.strimzi.kafka.KubernetesSecretConfigProvider
+        config.providers.configmaps.class: io.strimzi.kafka.KubernetesConfigMapConfigProvider
+      # ...
     ```
 
 2) Create a configuration Config Map
@@ -41,10 +41,10 @@ The following example shows how to use it with Kafka Connect and Connectors:
     apiVersion: v1
     kind: ConfigMap
     metadata:
-      name: connector-configuration
+      name: connector-configuration
     data:
-      option1: value1
-      option2: value2
+      option1: value1
+      option2: value2
     ```
 
 3) Create the Role and RoleBinding:
@@ -52,26 +52,26 @@ The following example shows how to use it with Kafka Connect and Connectors:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
-      name: connector-configuration-role
+      name: connector-configuration-role
     rules:
     - apiGroups: [""]
-      resources: ["configmaps"]
-      resourceNames: ["connector-configuration"]
-      verbs: ["get"]
+      resources: ["configmaps"]
+      resourceNames: ["connector-configuration"]
+      verbs: ["get"]
     ---
 
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
-      name: connector-configuration-role-binding
+      name: connector-configuration-role-binding
     subjects:
     - kind: ServiceAccount
-      name: my-connect-connect
-      namespace: myproject
+      name: my-connect-connect
+      namespace: myproject
     roleRef:
-      kind: Role
-      name: connector-configuration-role
-      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: connector-configuration-role
+      apiGroup: rbac.authorization.k8s.io
     ```
 
     Use the Service Account already used by your Kafka Connect deployment, which is named `<CLUSTER_NAME>-connect` where `<CLUSTER_NAME>` is the name of your KafkaConnect custom resource.
@@ -81,14 +81,14 @@ The following example shows how to use it with Kafka Connect and Connectors:
     apiVersion: kafka.strimzi.io/v1beta2
     kind: KafkaConnector
     metadata:
-      name: my-connector
-      labels:
-        strimzi.io/cluster: my-connect
+      name: my-connector
+      labels:
+        strimzi.io/cluster: my-connect
     spec:
-      # ...
-      config:
-        option: ${configmaps:myproject/connector-configuration:option1}
-        # ...
+      # ...
+      config:
+        option: ${configmaps:myproject/connector-configuration:option1}
+        # ...
     ```
 
 ## Adding the Kubernetes Configuration Provider to Apache Kafka clients
@@ -169,6 +169,41 @@ The following example shows how to use it in a Kafka Consumer consuming from Apa
     ssl.truststore.type=PEM
     ssl.truststore.certificates=${secrets:myproject/my-cluster-cluster-ca-cert:ca.crt}
     ```
+
+## Using patterns
+
+You can also use [Glob patterns](https://en.wikipedia.org/wiki/Glob_(programming)) to specify the keys in the Secret or Config Map that should be used.
+The Kubernetes Config Provider will find all fields matching the pattern and join them together into some value.
+This is useful for example when you want to load multiple certificates from a Secret into a single field.
+With an example Kubernetes Secret container multiple certificate files:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: certificates
+data:
+  ca.crt: ...
+  ca2.crt: ...
+  ca3.crt: ...
+```
+
+You can use the provider to load all of the certificates by using the key pattern `*.crt`:
+
+```properties
+config.providers=secrets
+config.providers.secrets.class=io.strimzi.kafka.KubernetesSecretConfigProvider
+...
+ssl.truststore.certificates=${secrets:myproject/certificates:*.crt}
+```
+
+By default, a new line will be used as a separator when joining the different values.
+But you can configure the separator if you want to use a different one:
+  ```properties
+  config.providers=secrets,configmaps
+  config.providers.secrets.class=io.strimzi.kafka.KubernetesSecretConfigProvider
+  config.providers.secrets.param.separator=,
+  ```
 
 ## Configuring the Kubernetes client
 

--- a/README.md
+++ b/README.md
@@ -172,9 +172,9 @@ The following example shows how to use it in a Kafka Consumer consuming from Apa
 
 ## Using patterns
 
-You can also use [Glob patterns](https://en.wikipedia.org/wiki/Glob_(programming)) to specify the keys in the Secret or Config Map that should be used.
-The Kubernetes Config Provider will find all fields matching the pattern and join them together into some value.
-This is useful for example when you want to load multiple certificates from a Secret into a single field.
+You can also use [Glob patterns](https://en.wikipedia.org/wiki/Glob_(programming)) to specify the keys in the Secret or ConfigMap that should be used.
+The Kubernetes Config Provider will find all fields matching the pattern and join them together into a single value.
+This is useful for example when you want to load multiple certificates from a Secret into a single configuration option.
 With an example Kubernetes Secret container multiple certificate files:
 
 ```yaml
@@ -199,11 +199,12 @@ ssl.truststore.certificates=${secrets:myproject/certificates:*.crt}
 
 By default, a new line will be used as a separator when joining the different values.
 But you can configure the separator if you want to use a different one:
-  ```properties
-  config.providers=secrets,configmaps
-  config.providers.secrets.class=io.strimzi.kafka.KubernetesSecretConfigProvider
-  config.providers.secrets.param.separator=,
-  ```
+
+```properties
+config.providers=secrets,configmaps
+config.providers.secrets.class=io.strimzi.kafka.KubernetesSecretConfigProvider
+config.providers.secrets.param.separator=,
+```
 
 ## Configuring the Kubernetes client
 


### PR DESCRIPTION
This PR ads support for loading multiple fields from a single Secret or ConfigMap based on a glob pattern. This is specifically intended for use with certificates, where it can be used to load all certificates based on a pattern such as `*.crt` (it uses Glob patterns already used in the [Strimzi Cluster operator](https://github.com/strimzi/proposals/blob/main/073-improve-handling-of-CA-renewals-and-replacements-in-client-based-operands.md)).

All matching fields in the given Secret or Config Map will be merged together and used as a single configuration value. By default, they will be separated by a new line. But users con configure other separators when needed using a configuration option.

Originally, I considered adding new providers (separate classes) for the pattern matching. But it should not be needed as this change should be backward compatible. All keys in the config provider will be treated as patterns. But because the keys in the ConfigMap or Secret must consist of `alphanumeric characters, '-', '_' or '.'`, treating them as patterns should not cause any backward compatibility issues:
* Keys such as `*.crt` are invalid and cannot be used as keys in ConfigMap or Secret. So it makes no sense to use them as the key in the previous versions of the config provider. So there should be no users using them right now.
* Keys with the record name such as `ca.crt` should even when treated as patterns match only the field named `ca.crt`. This is the same as before.

_The changes to the README file whitespace characters fix some wierd characters that we present in the file before this PR._