### PR TITLE
Update dependencies and fix pushing to Nexus

### DIFF
--- a/.azure/scripts/push-to-nexus.sh
+++ b/.azure/scripts/push-to-nexus.sh
@@ -1,12 +1,19 @@
 #!/usr/bin/env bash
+set -e
+
+function cleanup() {
+  rm -rf signing.gpg
+  gpg --delete-keys
+  gpg --delete-secret-keys
+}
+
+# Run the cleanup on failure / exit
+trap cleanup EXIT
 
 export GPG_TTY=$(tty)
-
 echo $GPG_SIGNING_KEY | base64 -d > signing.gpg
 gpg --batch --import signing.gpg
 
 GPG_EXECUTABLE=gpg mvn $MVN_ARGS -DskipTests -s ./.azure/scripts/settings.xml -P ossrh verify deploy
 
-rm -rf signing.gpg
-gpg --delete-keys
-gpg --delete-secret-keys
+cleanup

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,24 @@
             <organization>Red Hat</organization>
             <organizationUrl>https://www.redhat.com</organizationUrl>
         </developer>
+        <developer>
+            <name>Paul Mellor</name>
+            <email>pmellor@redhat.com</email>
+            <organization>Red Hat</organization>
+            <organizationUrl>https://www.redhat.com</organizationUrl>
+        </developer>
+        <developer>
+            <name>Lukáš Král</name>
+            <email>l.kral@outlook.com</email>
+            <organization>Red Hat</organization>
+            <organizationUrl>https://www.redhat.com</organizationUrl>
+        </developer>
+        <developer>
+            <name>Maroš Orsák</name>
+            <email>maros.orsak159@gmail.com</email>
+            <organization>Red Hat</organization>
+            <organizationUrl>https://www.redhat.com</organizationUrl>
+        </developer>
     </developers>
 
     <properties>
@@ -82,11 +100,11 @@
         <maven.jar.version>3.3.0</maven.jar.version>
         <maven.assembly.version>3.4.2</maven.assembly.version>
         <maven.gpg.version>3.0.1</maven.gpg.version>
-        <sonatype.nexus.staging>1.6.7</sonatype.nexus.staging>
+        <sonatype.nexus.staging>1.7.0</sonatype.nexus.staging>
 
-        <kafka.version>3.5.1</kafka.version>
+        <kafka.version>3.7.0</kafka.version>
         <slf4j.version>1.7.36</slf4j.version>
-        <fabric8-kubernetes-client.version>6.8.1</fabric8-kubernetes-client.version>
+        <fabric8-kubernetes-client.version>6.13.0</fabric8-kubernetes-client.version>
 
         <junit5.version>5.7.2</junit5.version>
         <hamcrest.version>2.2</hamcrest.version>
@@ -196,12 +214,6 @@
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-httpclient-jdk</artifactId>
             <version>${fabric8-kubernetes-client.version}</version>
-        </dependency>
-        <dependency>
-            <!-- Override for SnakeYAML 1.33 pulled by Jackson 1.14.2 -->
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-            <version>2.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
This PR updates several dependencies. The main update is to the Sonatype plugin as pushing to Sonnatype started to fail because the version is too old. But it also updates Kafka, Fabric8 and adds additional maintainers to the `pom.xml` file.

It also fixes the script for pushing to Nexus that is currently failing silently without us knowing.