### PR TITLE
Update dependencies before the next release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,9 +102,9 @@
         <maven.gpg.version>3.0.1</maven.gpg.version>
         <sonatype.nexus.staging>1.7.0</sonatype.nexus.staging>
 
-        <kafka.version>3.7.0</kafka.version>
+        <kafka.version>3.8.0</kafka.version>
         <slf4j.version>1.7.36</slf4j.version>
-        <fabric8-kubernetes-client.version>6.13.0</fabric8-kubernetes-client.version>
+        <fabric8-kubernetes-client.version>6.13.4</fabric8-kubernetes-client.version>
 
         <junit5.version>5.7.2</junit5.version>
         <hamcrest.version>2.2</hamcrest.version>


### PR DESCRIPTION
Somehow, we never got to do the new release with the new features. Before I proceed with the release, it would make sense to bump the dependnecies to the latest available.