### PR TITLE
Bump version in main branch to 1.3.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.strimzi</groupId>
     <artifactId>kafka-kubernetes-config-provider</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
 
     <licenses>
 		<license>


### PR DESCRIPTION
As we now have the 1.2.x release branched, we should bump the version in the main branch to 1.3.0-SNAPSHOT.