### PR TITLE
[provider] Retry transient Kubernetes API errors

### DIFF
--- a/.checkstyle/suppressions.xml
+++ b/.checkstyle/suppressions.xml
@@ -5,5 +5,10 @@
         "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 
 <suppressions>
-  <!-- No suppressions here -->
+  <!-- Retry classification test references several JDK exception types and a few test helpers,
+       which trips ClassDataAbstractionCoupling. The coupling is inherent to the test surface
+       (we cover SocketException/SocketTimeoutException/UnknownHostException/EOFException/etc.)
+       and not a code smell. -->
+  <suppress files="AbstractKubernetesConfigProviderRetryTest.java"
+            checks="ClassDataAbstractionCoupling"/>
 </suppressions>

--- a/src/main/java/io/strimzi/kafka/AbstractKubernetesConfigProvider.java
+++ b/src/main/java/io/strimzi/kafka/AbstractKubernetesConfigProvider.java
@@ -17,12 +17,19 @@ import org.apache.kafka.common.config.provider.ConfigProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.EOFException;
+import java.io.IOException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
 import java.nio.file.FileSystems;
 import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
 /**
@@ -36,10 +43,32 @@ abstract class AbstractKubernetesConfigProvider<T extends HasMetadata, L extends
     private static final Logger LOG = LoggerFactory.getLogger(AbstractKubernetesConfigProvider.class);
     private static final String SEPARATOR_CONFIG_NAME = "separator";
 
+    // Configuration property names for retry behavior. Overridable via Kafka Connect's
+    // `config.providers.<name>.param.<...>` mechanism so operators can tune without recompiling.
+    //
+    // Semantics: `max.retries = N` means N retries AFTER the initial attempt, for a total of
+    // N+1 attempts. With the defaults (N=5, 200ms..5s backoff) the worst-case startup latency
+    // is the sum of 5 sleeps capped at 5s ≈ 200+400+800+1600+3200 ≈ 6.2s, which fits under
+    // Kafka Connect's default config-provider timeout.
+    static final String MAX_RETRIES_CONFIG_NAME = "max.retries";
+    static final String INITIAL_BACKOFF_MS_CONFIG_NAME = "retry.backoff.ms";
+    static final String MAX_BACKOFF_MS_CONFIG_NAME = "retry.backoff.max.ms";
+
+    static final int DEFAULT_MAX_RETRIES = 5;
+    static final long DEFAULT_INITIAL_BACKOFF_MS = 200L;
+    static final long DEFAULT_MAX_BACKOFF_MS = 5_000L;
+
     protected final String kind;
 
     protected KubernetesClient client;
     private String separator = System.lineSeparator();
+
+    private int maxRetries = DEFAULT_MAX_RETRIES;
+    private long initialBackoffMs = DEFAULT_INITIAL_BACKOFF_MS;
+    private long maxBackoffMs = DEFAULT_MAX_BACKOFF_MS;
+
+    // Injectable seam for tests; production uses Thread.sleep.
+    private Sleeper sleeper = Thread::sleep;
 
     /**
      * Creates the configuration provider
@@ -70,7 +99,31 @@ abstract class AbstractKubernetesConfigProvider<T extends HasMetadata, L extends
             separator = (String) config.get(SEPARATOR_CONFIG_NAME);
         }
 
+        parseRetryConfig(config);
+
         client = new KubernetesClientBuilder().build();
+    }
+
+    /**
+     * Parses and validates the retry-related configuration keys. Single source of truth for
+     * both production ({@link #configure(Map)}) and the test seam ({@link #configureRetryForTest(Map)}),
+     * so future changes don't drift between the two.
+     */
+    private void parseRetryConfig(Map<String, ?> config) {
+        maxRetries = parseIntConfig(config, MAX_RETRIES_CONFIG_NAME, DEFAULT_MAX_RETRIES, 1, 50);
+        initialBackoffMs = parseLongConfig(config, INITIAL_BACKOFF_MS_CONFIG_NAME, DEFAULT_INITIAL_BACKOFF_MS, 1L, 60_000L);
+        // Parse max independently of initial so we can give a clearer error message when the
+        // user sets max < initial (parseLongConfig would otherwise log a generic "outside [min,max]").
+        long parsedMax = parseLongConfig(config, MAX_BACKOFF_MS_CONFIG_NAME, DEFAULT_MAX_BACKOFF_MS, 1L, 600_000L);
+        if (parsedMax < initialBackoffMs) {
+            LOG.warn("Config '{}' value {} is less than '{}' value {}; using default {} for the max backoff.",
+                    MAX_BACKOFF_MS_CONFIG_NAME, parsedMax,
+                    INITIAL_BACKOFF_MS_CONFIG_NAME, initialBackoffMs,
+                    DEFAULT_MAX_BACKOFF_MS);
+            maxBackoffMs = Math.max(DEFAULT_MAX_BACKOFF_MS, initialBackoffMs);
+        } else {
+            maxBackoffMs = parsedMax;
+        }
     }
 
     @Override
@@ -110,7 +163,12 @@ abstract class AbstractKubernetesConfigProvider<T extends HasMetadata, L extends
     // Kubernetes helper methods
 
     /**
-     * Gets the resource from Kubernetes
+     * Gets the resource from Kubernetes.
+     *
+     * Retries on transient API server errors (HTTP/2 GOAWAY, connection resets, 5xx server errors,
+     * 429 throttling, socket timeouts) using exponential backoff with full jitter. These errors
+     * commonly occur when the Kubernetes API server load-balances or gracefully terminates HTTP/2
+     * connections, and they should not cause the Connect pod to crash.
      *
      * @param path  Path to the Kubernetes resource
      *
@@ -118,20 +176,217 @@ abstract class AbstractKubernetesConfigProvider<T extends HasMetadata, L extends
      */
     protected T getResource(String path)   {
         final KubernetesResourceIdentifier resourceIdentifier = KubernetesResourceIdentifier.fromConfigString(client, path);
+        return getResourceWithRetry(resourceIdentifier,
+                () -> operator().inNamespace(resourceIdentifier.getNamespace()).withName(resourceIdentifier.getName()).get());
+    }
 
-        LOG.info("Retrieving configuration from {} {} in namespace {}", kind, resourceIdentifier.getName(), resourceIdentifier.getNamespace());
+    /**
+     * Core retry loop, extracted to be testable without mocking the full fabric8 client chain.
+     * Tests can call this directly with a Supplier that yields a queued series of results/errors.
+     *
+     * @param id       Identifier of the resource being fetched (used for logging only)
+     * @param fetch    Supplier that performs the actual Kubernetes API call
+     * @return         The fetched resource (never null)
+     */
+    T getResourceWithRetry(KubernetesResourceIdentifier id, java.util.function.Supplier<T> fetch) {
+        LOG.info("Retrieving configuration from {} {} in namespace {}", kind, id.getName(), id.getNamespace());
+
+        for (int attempt = 1; ; attempt++) {
+            try {
+                T resource = fetch.get();
+
+                if (resource == null)   {
+                    throw new ConfigException(kind +  " " + id.getName() + " in namespace " + id.getNamespace() + " not found");
+                }
+
+                if (attempt > 1) {
+                    LOG.info("Successfully retrieved {} {} from namespace {} after {} attempts",
+                            kind, id.getName(), id.getNamespace(), attempt);
+                }
+
+                return resource;
+            } catch (KubernetesClientException e) {
+                if (shouldRetry(e, attempt)) {
+                    sleepBeforeRetry(attempt, id, e);
+                    continue;
+                }
+                throw configException(id, e);
+            }
+        }
+    }
+
+    /**
+     * Decides whether the failed call should be retried. Returns true only if the exception is
+     * classified as transient AND we have remaining retry budget.
+     *
+     * `maxRetries` is the number of retries AFTER the initial attempt, so we allow another
+     * attempt whenever `attempt <= maxRetries` (i.e. up to `maxRetries + 1` total attempts).
+     *
+     * @param e         The exception thrown by the Kubernetes client
+     * @param attempt   The just-completed attempt number (1-indexed)
+     * @return          true if another attempt should be made
+     */
+    boolean shouldRetry(KubernetesClientException e, int attempt) {
+        return attempt <= maxRetries && isTransient(e);
+    }
+
+    /**
+     * Classifies an exception as transient based on the structured fields of the
+     * {@link KubernetesClientException} (HTTP status code) and well-known transport-layer
+     * exception types in the cause chain. Message-string matching is used only as a last
+     * resort for HTTP/2 GOAWAY, which has no dedicated exception type in the JDK HTTP client.
+     *
+     * @param e the exception thrown by the Kubernetes client
+     * @return true if the error appears to be a recoverable network or server-side condition
+     */
+    boolean isTransient(KubernetesClientException e) {
+        if (isRetryableHttpCode(e.getCode())) {
+            return true;
+        }
+        // Walk the cause chain for transport-level exception types or a GOAWAY message.
+        for (Throwable cause = e; cause != null; cause = cause.getCause()) {
+            if (isTransientCause(cause)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Retryable HTTP status codes: request timeout, throttling, and the 5xx server-side errors
+     * we know to be transient.
+     */
+    private static boolean isRetryableHttpCode(int code) {
+        switch (code) {
+            case 408: // Request Timeout
+            case 429: // Too Many Requests
+            case 500: // Internal Server Error
+            case 502: // Bad Gateway
+            case 503: // Service Unavailable
+            case 504: // Gateway Timeout
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    /**
+     * Classifies a single Throwable in the cause chain. SocketException covers ConnectException
+     * and friends; UnknownHostException covers DNS hiccups during apiserver / load-balancer
+     * failover. GOAWAY is matched only on IOException to stay narrow — auth failures and other
+     * permanent errors also surface as IOException in some fabric8 code paths.
+     */
+    private static boolean isTransientCause(Throwable cause) {
+        if (cause instanceof SocketException
+                || cause instanceof SocketTimeoutException
+                || cause instanceof UnknownHostException
+                || cause instanceof EOFException) {
+            return true;
+        }
+        // Case-insensitive match in case the JDK ever rewords the message.
+        return cause instanceof IOException
+                && cause.getMessage() != null
+                && cause.getMessage().toUpperCase(Locale.ROOT).contains("GOAWAY");
+    }
+
+    private void sleepBeforeRetry(int attempt, KubernetesResourceIdentifier id, KubernetesClientException cause) {
+        // Exponential backoff with full jitter: random in [base/2, base) to avoid thundering herd.
+        // Cap the left shift at 30 to keep the multiplier inside positive long range even if a
+        // future change raises the maxRetries upper bound above 31.
+        long base = Math.min(initialBackoffMs * (1L << Math.min(attempt - 1, 30)), maxBackoffMs);
+        long backoff = ThreadLocalRandom.current().nextLong(Math.max(1L, base / 2), Math.max(2L, base));
+
+        LOG.warn("Transient error retrieving {} {} from namespace {} (attempt {}/{}): {}. Retrying in {} ms.",
+                kind, id.getName(), id.getNamespace(), attempt, maxRetries + 1, cause.getMessage(), backoff);
 
         try {
-            T resource = operator().inNamespace(resourceIdentifier.getNamespace()).withName(resourceIdentifier.getName()).get();
-
-            if (resource == null)   {
-                throw new ConfigException(kind +  " " + resourceIdentifier.getName() + " in namespace " + resourceIdentifier.getNamespace() + " not found");
-            }
-
-            return resource;
-        } catch (KubernetesClientException e)   {
-            LOG.error("Failed to retrieve {} {} from Kubernetes namespace {}", kind, resourceIdentifier.getName(), resourceIdentifier.getNamespace(), e);
-            throw new ConfigException("Failed to retrieve " + kind +  " " + resourceIdentifier.getName() + " from Kubernetes namespace " + resourceIdentifier.getNamespace());
+            sleeper.sleep(backoff);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            // Preserve the underlying transient error in the cause chain for debugging.
+            // Kafka's ConfigException lacks a (message, cause) constructor, so we use initCause().
+            throw (ConfigException) new ConfigException("Interrupted while retrying to retrieve "
+                    + kind + " " + id.getName() + " from namespace " + id.getNamespace()).initCause(cause);
         }
+    }
+
+    private ConfigException configException(KubernetesResourceIdentifier id, KubernetesClientException e) {
+        LOG.error("Failed to retrieve {} {} from Kubernetes namespace {}", kind, id.getName(), id.getNamespace(), e);
+        // Kafka's ConfigException lacks a (message, cause) constructor; chain via initCause().
+        return (ConfigException) new ConfigException("Failed to retrieve " + kind + " " + id.getName()
+                + " from Kubernetes namespace " + id.getNamespace()).initCause(e);
+    }
+
+    private static int parseIntConfig(Map<String, ?> config, String name, int defaultValue, int min, int max) {
+        Object raw = config.get(name);
+        if (raw == null) {
+            return defaultValue;
+        }
+        try {
+            int v = Integer.parseInt(raw.toString());
+            if (v < min || v > max) {
+                LOG.warn("Config '{}' value {} is outside [{},{}], using default {}", name, v, min, max, defaultValue);
+                return defaultValue;
+            }
+            return v;
+        } catch (NumberFormatException nfe) {
+            LOG.warn("Config '{}' value '{}' is not a valid integer, using default {}", name, raw, defaultValue);
+            return defaultValue;
+        }
+    }
+
+    private static long parseLongConfig(Map<String, ?> config, String name, long defaultValue, long min, long max) {
+        Object raw = config.get(name);
+        if (raw == null) {
+            return defaultValue;
+        }
+        try {
+            long v = Long.parseLong(raw.toString());
+            if (v < min || v > max) {
+                LOG.warn("Config '{}' value {} is outside [{},{}], using default {}", name, v, min, max, defaultValue);
+                return defaultValue;
+            }
+            return v;
+        } catch (NumberFormatException nfe) {
+            LOG.warn("Config '{}' value '{}' is not a valid long, using default {}", name, raw, defaultValue);
+            return defaultValue;
+        }
+    }
+
+    // ─── Test-only seams ─────────────────────────────────────────────────────────────
+
+    /**
+     * Functional interface so unit tests can substitute a no-op or fake clock for Thread.sleep.
+     */
+    @FunctionalInterface
+    interface Sleeper {
+        void sleep(long millis) throws InterruptedException;
+    }
+
+    // Visible-for-testing: replace the default Thread::sleep so tests don't actually wait.
+    void setSleeper(Sleeper sleeper) {
+        this.sleeper = sleeper;
+    }
+
+    // Visible-for-testing accessors for retry configuration.
+    int getMaxRetries() {
+        return maxRetries;
+    }
+
+    long getInitialBackoffMs() {
+        return initialBackoffMs;
+    }
+
+    long getMaxBackoffMs() {
+        return maxBackoffMs;
+    }
+
+    /**
+     * Visible-for-testing helper that applies retry-related configuration without constructing a
+     * real KubernetesClient. Delegates to {@link #parseRetryConfig(Map)} so the parsing logic
+     * stays in a single place.
+     */
+    void configureRetryForTest(Map<String, ?> config) {
+        parseRetryConfig(config);
     }
 }

--- a/src/main/java/io/strimzi/kafka/KubernetesResourceIdentifier.java
+++ b/src/main/java/io/strimzi/kafka/KubernetesResourceIdentifier.java
@@ -14,7 +14,9 @@ final class KubernetesResourceIdentifier {
     private final String namespace;
     private final String name;
 
-    private KubernetesResourceIdentifier(String namespace, String name) {
+    // Package-private to allow direct construction from unit tests (e.g. for the retry test
+    // which bypasses path parsing). Production code paths must go through fromConfigString.
+    KubernetesResourceIdentifier(String namespace, String name) {
         this.namespace = namespace;
         this.name = name;
     }

--- a/src/test/java/io/strimzi/kafka/AbstractKubernetesConfigProviderRetryIT.java
+++ b/src/test/java/io/strimzi/kafka/AbstractKubernetesConfigProviderRetryIT.java
@@ -1,0 +1,307 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.ConfigMapList;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ConfigBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import org.apache.kafka.common.config.ConfigException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end retry IT against a real Kubernetes cluster.
+ *
+ * Sits a TCP-forwarding proxy in front of the apiserver. The proxy kills the first N connections
+ * with a TCP RST (which fabric8 surfaces as {@link java.net.SocketException}, classified as
+ * transient by the production code), then forwards transparently. We then make a single provider
+ * call through the production retry loop and verify it actually recovers — using a real
+ * fabric8 client, real network, and real TLS to a real apiserver.
+ *
+ * This complements the unit tests by exercising the parts they can't: real fabric8 client
+ * wiring, real exception types produced by real network failures, and real connection re-use
+ * behavior across retries.
+ */
+public class AbstractKubernetesConfigProviderRetryIT {
+
+    private static final String RESOURCE_NAME = "retry-it-cm";
+
+    private static KubernetesClient realClient;
+    private static String namespace;
+    private static URI masterUri;
+
+    // Per-test state: each test creates a fresh proxy and fresh fabric8 client so that
+    // HTTP/1.1 keepalive from a previous test cannot mask the next test's failure injection.
+    private FailingTcpProxy proxy;
+    private KubernetesClient proxiedClient;
+
+    @BeforeAll
+    public static void beforeAll() {
+        realClient = new KubernetesClientBuilder().build();
+        namespace = realClient.getNamespace();
+        masterUri = URI.create(realClient.getConfiguration().getMasterUrl());
+
+        ConfigMap cm = new ConfigMapBuilder()
+                .withNewMetadata()
+                    .withName(RESOURCE_NAME)
+                    .withNamespace(namespace)
+                .endMetadata()
+                .addToData("hello", "world")
+                .build();
+        realClient.configMaps().resource(cm).create();
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        if (realClient != null) {
+            try {
+                realClient.configMaps().inNamespace(namespace).withName(RESOURCE_NAME).delete();
+            } catch (Exception ignored) {
+                // best-effort cleanup
+            }
+            realClient.close();
+        }
+    }
+
+    @BeforeEach
+    public void beforeEach() throws IOException {
+        int targetPort = masterUri.getPort() > 0 ? masterUri.getPort() : 443;
+        proxy = new FailingTcpProxy(masterUri.getHost(), targetPort);
+        proxy.start();
+
+        // autoConfigure() preserves the kubeconfig client cert/key so TLS client-auth still
+        // works against the real apiserver; we just bypass hostname + CA validation since the
+        // bytes are tunnelled through a localhost endpoint. http2Disable=true forces HTTP/1.1,
+        // so each retry from the production loop opens (or attempts to open) a new TCP
+        // connection — making each retry observable at the proxy's connection counter.
+        Config base = Config.autoConfigure(null);
+        Config cfg = new ConfigBuilder(base)
+                .withMasterUrl("https://localhost:" + proxy.getPort())
+                .withTrustCerts(true)
+                .withDisableHostnameVerification(true)
+                .withHttp2Disable(true)
+                .withRequestTimeout(5_000)
+                .build();
+        proxiedClient = new KubernetesClientBuilder().withConfig(cfg).build();
+    }
+
+    @AfterEach
+    public void afterEach() throws IOException {
+        if (proxiedClient != null) {
+            proxiedClient.close();
+        }
+        if (proxy != null) {
+            proxy.close();
+        }
+    }
+
+    @Test
+    public void retryLoopRecoversFromRealNetworkFailures() {
+        proxy.resetCounter();
+        proxy.setFailCount(3);
+
+        TestConfigMapProvider provider = new TestConfigMapProvider(proxiedClient);
+        provider.configureRetryForTest(Map.of(
+                AbstractKubernetesConfigProvider.MAX_RETRIES_CONFIG_NAME, "15",
+                AbstractKubernetesConfigProvider.INITIAL_BACKOFF_MS_CONFIG_NAME, "10",
+                AbstractKubernetesConfigProvider.MAX_BACKOFF_MS_CONFIG_NAME, "50"
+        ));
+        provider.setSleeper(ms -> { /* no actual sleep — keep the test fast */ });
+
+        KubernetesResourceIdentifier id = new KubernetesResourceIdentifier(namespace, RESOURCE_NAME);
+
+        ConfigMap got = provider.getResourceWithRetry(id,
+                () -> proxiedClient.configMaps().inNamespace(namespace).withName(RESOURCE_NAME).get());
+
+        assertNotNull(got, "Provider should recover after transient failures");
+        assertEquals("world", got.getData().get("hello"),
+                "Recovered ConfigMap should carry the expected data");
+        assertTrue(proxy.getConnectionCount() > 3,
+                "Proxy should have seen more than 3 connections (failures + at least one success); got "
+                        + proxy.getConnectionCount());
+    }
+
+    @Test
+    public void exhaustingRetriesAgainstRealNetworkThrowsWithCause() {
+        proxy.resetCounter();
+        proxy.setFailCount(Integer.MAX_VALUE);
+
+        TestConfigMapProvider provider = new TestConfigMapProvider(proxiedClient);
+        provider.configureRetryForTest(Map.of(
+                AbstractKubernetesConfigProvider.MAX_RETRIES_CONFIG_NAME, "2",
+                AbstractKubernetesConfigProvider.INITIAL_BACKOFF_MS_CONFIG_NAME, "10",
+                AbstractKubernetesConfigProvider.MAX_BACKOFF_MS_CONFIG_NAME, "50"
+        ));
+        provider.setSleeper(ms -> { });
+
+        KubernetesResourceIdentifier id = new KubernetesResourceIdentifier(namespace, RESOURCE_NAME);
+
+        ConfigException ce = assertThrows(ConfigException.class,
+                () -> provider.getResourceWithRetry(id,
+                        () -> proxiedClient.configMaps().inNamespace(namespace).withName(RESOURCE_NAME).get()));
+
+        assertNotNull(ce.getCause(), "Real KubernetesClientException must be preserved as cause");
+        assertTrue(ce.getCause() instanceof KubernetesClientException,
+                "Cause should be the actual fabric8 exception, got: " + ce.getCause().getClass());
+    }
+
+    /** Concrete provider subclass that uses a caller-provided KubernetesClient. */
+    static final class TestConfigMapProvider extends AbstractKubernetesConfigProvider<ConfigMap, ConfigMapList, Resource<ConfigMap>> {
+        TestConfigMapProvider(KubernetesClient client) {
+            super("ConfigMap");
+            this.client = client;
+        }
+
+        @Override
+        protected MixedOperation<ConfigMap, ConfigMapList, Resource<ConfigMap>> operator() {
+            return client.configMaps();
+        }
+
+        @Override
+        protected Map<String, String> valuesFromResource(ConfigMap resource) {
+            Map<String, String> out = new HashMap<>();
+            if (resource.getData() != null) {
+                out.putAll(resource.getData());
+            }
+            return out;
+        }
+    }
+
+    /**
+     * TCP proxy that forwards bytes between a client and a target host:port, but kills the first
+     * {@code failCount} accepted connections with a TCP RST. Counted at TCP accept time, so each
+     * retry from the production loop (with HTTP/2 disabled) maps to one new connection here.
+     */
+    static final class FailingTcpProxy implements Closeable {
+        private final String targetHost;
+        private final int targetPort;
+        private final ServerSocket serverSocket;
+        private final Thread acceptThread;
+        private final AtomicInteger connectionCount = new AtomicInteger();
+        private volatile int failCount = 0;
+        private volatile boolean running = true;
+
+        FailingTcpProxy(String targetHost, int targetPort) throws IOException {
+            this.targetHost = targetHost;
+            this.targetPort = targetPort;
+            this.serverSocket = new ServerSocket(0);
+            this.acceptThread = new Thread(this::acceptLoop, "FailingTcpProxy-accept");
+            this.acceptThread.setDaemon(true);
+        }
+
+        void start() {
+            acceptThread.start();
+        }
+
+        int getPort() {
+            return serverSocket.getLocalPort();
+        }
+
+        int getConnectionCount() {
+            return connectionCount.get();
+        }
+
+        void setFailCount(int f) {
+            this.failCount = f;
+        }
+
+        void resetCounter() {
+            this.connectionCount.set(0);
+        }
+
+        private void acceptLoop() {
+            while (running) {
+                try {
+                    Socket client = serverSocket.accept();
+                    int n = connectionCount.incrementAndGet();
+                    if (n <= failCount) {
+                        // SO_LINGER 0 → close sends TCP RST. Client side sees SocketException
+                        // ("Connection reset"), which our classifier treats as transient.
+                        try {
+                            client.setSoLinger(true, 0);
+                        } catch (Exception ignored) {
+                            // some platforms reject SO_LINGER 0; fall through and just close
+                        }
+                        try {
+                            client.close();
+                        } catch (IOException ignored) {
+                            // already torn down
+                        }
+                    } else {
+                        Socket upstream = new Socket(targetHost, targetPort);
+                        Thread t1 = new Thread(() -> pipe(client, upstream), "FailingTcpProxy-c2u");
+                        Thread t2 = new Thread(() -> pipe(upstream, client), "FailingTcpProxy-u2c");
+                        t1.setDaemon(true);
+                        t2.setDaemon(true);
+                        t1.start();
+                        t2.start();
+                    }
+                } catch (IOException e) {
+                    if (running) {
+                        System.err.println("FailingTcpProxy accept error: " + e);
+                    }
+                }
+            }
+        }
+
+        private static void pipe(Socket inSock, Socket outSock) {
+            try {
+                InputStream in = inSock.getInputStream();
+                OutputStream out = outSock.getOutputStream();
+                byte[] buf = new byte[8192];
+                int n;
+                while ((n = in.read(buf)) > 0) {
+                    out.write(buf, 0, n);
+                    out.flush();
+                }
+            } catch (IOException ignored) {
+                // expected on connection close
+            } finally {
+                try {
+                    inSock.close();
+                } catch (IOException ignored) {
+                    // already closed
+                }
+                try {
+                    outSock.close();
+                } catch (IOException ignored) {
+                    // already closed
+                }
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            running = false;
+            serverSocket.close();
+        }
+    }
+}

--- a/src/test/java/io/strimzi/kafka/AbstractKubernetesConfigProviderRetryTest.java
+++ b/src/test/java/io/strimzi/kafka/AbstractKubernetesConfigProviderRetryTest.java
@@ -1,0 +1,368 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.ConfigMapList;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import org.apache.kafka.common.config.ConfigException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests covering the retry / transient-error classification behavior added to
+ * {@link AbstractKubernetesConfigProvider}. Tests use a fake {@link AbstractKubernetesConfigProvider.Sleeper}
+ * so the suite runs in milliseconds, and call the retry loop directly via a Supplier to avoid
+ * mocking the full fabric8 client chain.
+ */
+class AbstractKubernetesConfigProviderRetryTest {
+
+    private TestProvider provider;
+    private AtomicInteger sleepCount;
+    private long totalSleptMs;
+
+    @BeforeEach
+    void setUp() {
+        provider = new TestProvider();
+        provider.configureRetryForTest(Map.of(
+                AbstractKubernetesConfigProvider.MAX_RETRIES_CONFIG_NAME, "3",
+                AbstractKubernetesConfigProvider.INITIAL_BACKOFF_MS_CONFIG_NAME, "10",
+                AbstractKubernetesConfigProvider.MAX_BACKOFF_MS_CONFIG_NAME, "100"
+        ));
+        sleepCount = new AtomicInteger();
+        totalSleptMs = 0;
+        provider.setSleeper(ms -> {
+            sleepCount.incrementAndGet();
+            totalSleptMs += ms;
+        });
+    }
+
+    // ─── isTransient classification ──────────────────────────────────────────────────
+
+    @Test
+    void retryableHttpCodesAreTransient() {
+        for (int code : new int[]{408, 429, 500, 502, 503, 504}) {
+            assertTrue(provider.isTransient(new KubernetesClientException("boom", code, null)),
+                    "HTTP " + code + " should be transient");
+        }
+    }
+
+    @Test
+    void permanentHttpCodesAreNotTransient() {
+        for (int code : new int[]{400, 401, 403, 404, 409, 422}) {
+            assertFalse(provider.isTransient(new KubernetesClientException("boom", code, null)),
+                    "HTTP " + code + " should be permanent");
+        }
+    }
+
+    @Test
+    void goawayInCauseChainIsTransient() {
+        KubernetesClientException e = new KubernetesClientException("wrap",
+                new IOException("/10.0.0.1:8443: GOAWAY received"));
+        assertTrue(provider.isTransient(e));
+    }
+
+    @Test
+    void socketTimeoutInCauseChainIsTransient() {
+        KubernetesClientException e = new KubernetesClientException("wrap",
+                new SocketTimeoutException("read timed out"));
+        assertTrue(provider.isTransient(e));
+    }
+
+    @Test
+    void eofExceptionInCauseChainIsTransient() {
+        KubernetesClientException e = new KubernetesClientException("wrap",
+                new EOFException("unexpected end of stream"));
+        assertTrue(provider.isTransient(e));
+    }
+
+    @Test
+    void unknownHostExceptionInCauseChainIsTransient() {
+        // DNS hiccups during apiserver / load-balancer failover.
+        KubernetesClientException e = new KubernetesClientException("wrap",
+                new UnknownHostException("kubernetes.default.svc"));
+        assertTrue(provider.isTransient(e));
+    }
+
+    @Test
+    void goawayMatchIsCaseInsensitive() {
+        KubernetesClientException e = new KubernetesClientException("wrap",
+                new IOException("/10.0.0.1:8443: goaway received"));
+        assertTrue(provider.isTransient(e));
+    }
+
+    @Test
+    void plainIOExceptionWithoutGoawayIsNotTransient() {
+        // Deliberately narrow: we don't retry on every IOException because auth failures and
+        // other real errors also surface as IOExceptions in some fabric8 code paths.
+        KubernetesClientException e = new KubernetesClientException("wrap",
+                new IOException("authentication failed"));
+        assertFalse(provider.isTransient(e));
+    }
+
+    @Test
+    void unrelatedExceptionIsNotTransient() {
+        assertFalse(provider.isTransient(new KubernetesClientException("bad config")));
+    }
+
+    // ─── retry loop behavior ─────────────────────────────────────────────────────────
+
+    @Test
+    void returnsImmediatelyOnSuccessWithoutSleeping() {
+        Queued queued = new Queued().enqueue(configMap());
+
+        ConfigMap got = provider.getResourceWithRetry(id(), queued);
+
+        assertNotNull(got);
+        assertEquals(0, sleepCount.get(), "Should not sleep on first-try success");
+    }
+
+    @Test
+    void retriesTransientErrorThenSucceeds() {
+        ConfigMap cm = configMap();
+        Queued queued = new Queued()
+                .enqueue(transientGoaway())
+                .enqueue(transient503())
+                .enqueue(cm);
+
+        ConfigMap got = provider.getResourceWithRetry(id(), queued);
+
+        assertSame(cm, got);
+        assertEquals(2, sleepCount.get(), "Two retries should mean two sleeps");
+        assertTrue(totalSleptMs >= 10, "Backoff should have elapsed at least one initial interval");
+    }
+
+    @Test
+    void exhaustsRetriesThenThrowsConfigExceptionPreservingCause() {
+        KubernetesClientException last = transient503();
+        // maxRetries=3 means 3 retries AFTER the initial attempt: 4 total attempts, 3 sleeps.
+        Queued queued = new Queued()
+                .enqueue(transientGoaway())
+                .enqueue(transient503())
+                .enqueue(transientGoaway())
+                .enqueue(last);
+
+        ConfigException ce = assertThrows(ConfigException.class,
+                () -> provider.getResourceWithRetry(id(), queued));
+
+        assertEquals(3, sleepCount.get(), "Should sleep maxRetries times before giving up");
+        assertNotNull(ce.getCause(), "Cause must be preserved for debugging");
+        assertSame(last, ce.getCause());
+    }
+
+    @Test
+    void doesNotRetryOnPermanentError() {
+        KubernetesClientException notFound = new KubernetesClientException("not found", 404, null);
+        Queued queued = new Queued().enqueue(notFound);
+
+        ConfigException ce = assertThrows(ConfigException.class,
+                () -> provider.getResourceWithRetry(id(), queued));
+
+        assertEquals(0, sleepCount.get(), "Permanent errors must not be retried");
+        assertSame(notFound, ce.getCause());
+    }
+
+    @Test
+    void nullResourceTreatedAsNotFoundWithoutRetry() {
+        Queued queued = new Queued().enqueue((ConfigMap) null);
+
+        ConfigException ce = assertThrows(ConfigException.class,
+                () -> provider.getResourceWithRetry(id(), queued));
+
+        assertEquals(0, sleepCount.get(), "Null (not-found) is not retried");
+        assertTrue(ce.getMessage().contains("not found"));
+    }
+
+    @Test
+    void backoffIsBoundedByMax() {
+        TestProvider tp = new TestProvider();
+        // maxRetries=20 → 21 total attempts, 20 sleeps.
+        tp.configureRetryForTest(Map.of(
+                AbstractKubernetesConfigProvider.MAX_RETRIES_CONFIG_NAME, "20",
+                AbstractKubernetesConfigProvider.INITIAL_BACKOFF_MS_CONFIG_NAME, "1",
+                AbstractKubernetesConfigProvider.MAX_BACKOFF_MS_CONFIG_NAME, "50"
+        ));
+        long[] observed = new long[20];
+        AtomicInteger idx = new AtomicInteger();
+        tp.setSleeper(ms -> observed[idx.getAndIncrement()] = ms);
+
+        Queued queued = new Queued();
+        for (int i = 0; i < 21; i++) {
+            queued.enqueue(transientGoaway());
+        }
+
+        assertThrows(ConfigException.class, () -> tp.getResourceWithRetry(id(), queued));
+
+        for (long ms : observed) {
+            assertTrue(ms >= 1 && ms <= 50, "Sleep " + ms + "ms must be within [1, 50]");
+        }
+    }
+
+    @Test
+    void interruptDuringBackoffPreservesCauseAndReinterruptsThread() {
+        provider.setSleeper(ms -> {
+            throw new InterruptedException("test interrupt");
+        });
+        KubernetesClientException transient1 = transientGoaway();
+        Queued queued = new Queued().enqueue(transient1).enqueue(configMap());
+
+        ConfigException ce = assertThrows(ConfigException.class,
+                () -> provider.getResourceWithRetry(id(), queued));
+
+        assertTrue(Thread.interrupted(), "Thread interrupt status must be restored");
+        assertSame(transient1, ce.getCause(),
+                "Underlying transient error should be preserved when interrupted");
+    }
+
+    @Test
+    void invalidRetryConfigFallsBackToDefaults() {
+        TestProvider tp = new TestProvider();
+        tp.configureRetryForTest(Map.of(
+                AbstractKubernetesConfigProvider.MAX_RETRIES_CONFIG_NAME, "not-a-number",
+                AbstractKubernetesConfigProvider.INITIAL_BACKOFF_MS_CONFIG_NAME, "-5"
+        ));
+
+        assertEquals(AbstractKubernetesConfigProvider.DEFAULT_MAX_RETRIES, tp.getMaxRetries());
+        assertEquals(AbstractKubernetesConfigProvider.DEFAULT_INITIAL_BACKOFF_MS, tp.getInitialBackoffMs());
+    }
+
+    @Test
+    void maxBackoffLessThanInitialFallsBackToDefault() {
+        TestProvider tp = new TestProvider();
+        tp.configureRetryForTest(Map.of(
+                AbstractKubernetesConfigProvider.INITIAL_BACKOFF_MS_CONFIG_NAME, "5000",
+                AbstractKubernetesConfigProvider.MAX_BACKOFF_MS_CONFIG_NAME, "3000"
+        ));
+
+        assertEquals(5000L, tp.getInitialBackoffMs());
+        // max < initial: fall back to DEFAULT_MAX_BACKOFF_MS (or initial if larger).
+        long expected = Math.max(AbstractKubernetesConfigProvider.DEFAULT_MAX_BACKOFF_MS, tp.getInitialBackoffMs());
+        assertEquals(expected, tp.getMaxBackoffMs());
+    }
+
+    @Test
+    void maxRetriesOneMeansOneInitialPlusOneRetry() {
+        // Verifies the documented semantics: max.retries = N means N retries AFTER the initial,
+        // for N+1 total attempts.
+        TestProvider tp = new TestProvider();
+        tp.configureRetryForTest(Map.of(
+                AbstractKubernetesConfigProvider.MAX_RETRIES_CONFIG_NAME, "1",
+                AbstractKubernetesConfigProvider.INITIAL_BACKOFF_MS_CONFIG_NAME, "5",
+                AbstractKubernetesConfigProvider.MAX_BACKOFF_MS_CONFIG_NAME, "10"
+        ));
+        AtomicInteger sleeps = new AtomicInteger();
+        tp.setSleeper(ms -> sleeps.incrementAndGet());
+
+        // Two transient errors → first sleeps (retry once), second is the final attempt.
+        Queued queued = new Queued()
+                .enqueue(transientGoaway())
+                .enqueue(transient503());
+
+        assertThrows(ConfigException.class, () -> tp.getResourceWithRetry(id(), queued));
+        assertEquals(1, sleeps.get(), "maxRetries=1 should sleep exactly once");
+    }
+
+    // ─── helpers ────────────────────────────────────────────────────────────────────
+
+    private static ConfigMap configMap() {
+        return new ConfigMapBuilder()
+                .withNewMetadata().withName("foo").withNamespace("kafka").endMetadata()
+                .addToData("key", "value")
+                .build();
+    }
+
+    private static KubernetesResourceIdentifier id() {
+        // Constructor is (namespace, name); match the ConfigMap built in configMap().
+        return new KubernetesResourceIdentifier("kafka", "foo");
+    }
+
+    private static KubernetesClientException transientGoaway() {
+        return new KubernetesClientException("transport failure",
+                new IOException("/10.0.0.1:8443: GOAWAY received"));
+    }
+
+    private static KubernetesClientException transient503() {
+        return new KubernetesClientException("service unavailable", 503, null);
+    }
+
+    /**
+     * Queueable supplier: each call to get() returns or throws the next enqueued item.
+     */
+    private static final class Queued implements Supplier<ConfigMap> {
+        private final Deque<Object> items = new ArrayDeque<>();
+        private final Object nullSentinel = new Object();
+
+        Queued enqueue(ConfigMap cm) {
+            items.add(cm == null ? nullSentinel : cm);
+            return this;
+        }
+
+        Queued enqueue(KubernetesClientException e) {
+            items.add(e);
+            return this;
+        }
+
+        @Override
+        public ConfigMap get() {
+            Object next = items.poll();
+            if (next == null) {
+                throw new IllegalStateException("Queued supplier exhausted");
+            }
+            if (next == nullSentinel) {
+                return null;
+            }
+            if (next instanceof KubernetesClientException) {
+                throw (KubernetesClientException) next;
+            }
+            return (ConfigMap) next;
+        }
+    }
+
+    /**
+     * Minimal concrete subclass — we never actually call operator() in these tests because
+     * the suite goes through getResourceWithRetry() with its own Supplier, bypassing the
+     * fabric8 client chain entirely.
+     */
+    static final class TestProvider extends AbstractKubernetesConfigProvider<ConfigMap, ConfigMapList, Resource<ConfigMap>> {
+        TestProvider() {
+            super("ConfigMap");
+        }
+
+        @Override
+        protected MixedOperation<ConfigMap, ConfigMapList, Resource<ConfigMap>> operator() {
+            throw new UnsupportedOperationException("operator() should not be invoked in unit tests");
+        }
+
+        @Override
+        protected Map<String, String> valuesFromResource(ConfigMap resource) {
+            Map<String, String> out = new HashMap<>();
+            if (resource.getData() != null) {
+                out.putAll(resource.getData());
+            }
+            return out;
+        }
+    }
+}


### PR DESCRIPTION
## Type of change

- [x] Bugfix
- [x] Enhancement / new feature

## Description

The config provider currently treats every `KubernetesClientException` as fatal, including transient transport errors such as HTTP/2 GOAWAY frames, connection resets, and 5xx/429 responses. In environments where the apiserver load-balancer recycles HTTP/2 connections every ~20 minutes, the JDK HttpClient surfaces a GOAWAY as:

```
java.io.IOException: /<ip>:<port>: GOAWAY received
```

This causes `ConnectDistributed` to abort, the MirrorMaker 2 / Connect pod restarts, and the cycle repeats. The actual root cause is benign and should be retried.

### Changes

- Wrap the fetch in a **bounded retry loop with exponential backoff and full jitter** (defaults: 5 retries after the initial attempt, 200ms..5s backoff bounds, worst-case startup latency ~6.2s).
- **Classify transient errors structurally**:
  - HTTP `408 / 429 / 500 / 502 / 503 / 504`
  - `SocketException`, `SocketTimeoutException`, `UnknownHostException`, `EOFException` in the cause chain
  - GOAWAY-bearing `IOException` (narrow, case-insensitive message match, only for `IOException` so unrelated failures aren't swallowed)
- **Make retry parameters configurable** via Connect's `config.providers.<name>.param.*`:
  - `max.retries` (default 5, retries **after** the initial attempt)
  - `retry.backoff.ms` (default 200)
  - `retry.backoff.max.ms` (default 5000)

  Invalid values fall back to defaults with a warning. `retry.backoff.max.ms` below `retry.backoff.ms` logs an explicit warning and falls back.
- **Preserve the underlying `KubernetesClientException` as the cause** of any `ConfigException` so the original stack trace survives to logs.
- Extract the retry loop into `getResourceWithRetry(id, Supplier<T>)` so it can be unit-tested without mocking the fabric8 client chain.

### Worst-case startup latency

With defaults (5 retries, 200ms initial, 5s max), worst case is `200+400+800+1600+3200 ≈ 6.2s`, well under Kafka Connect's default config-provider timeout. Operators can tune lower for CI or higher for flaky environments.

## Checklist

- [x] Write tests
- [x] Make sure all tests pass

### Tests

**19 unit tests** in `AbstractKubernetesConfigProviderRetryTest` cover:

- HTTP status code classification (retryable vs permanent)
- Exception cause-chain detection (`GOAWAY`, `SocketTimeoutException`, `EOFException`, `UnknownHostException`)
- Case-insensitive GOAWAY match
- Narrow `IOException` matching (does NOT retry on plain `"authentication failed"`)
- Immediate success without sleeping; retry-then-succeed
- Exhausted retries throwing `ConfigException` with preserved cause
- Permanent errors (404) not retried; null resource not retried
- Backoff bounded by max cap
- Interrupt handling preserves cause + re-interrupts thread
- Invalid config falls back to defaults
- `maxRetries=1` boundary; `retry.backoff.max.ms` < `retry.backoff.ms` fallback

A new **`AbstractKubernetesConfigProviderRetryIT`** exercises the retry loop end-to-end against a real Kubernetes apiserver through a real fabric8 client. An in-process TCP proxy in front of the apiserver kills the first N connections with a TCP RST (surfaced as `SocketException`), then becomes a transparent byte-pump. Two scenarios:

- Recover from N real network failures and return the expected `ConfigMap`.
- Exhaust retries and throw `ConfigException` with the real `KubernetesClientException` preserved as cause.

```
[INFO] Tests run: 23 (unit) + 18 (IT) = 41
[INFO] Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```
